### PR TITLE
Update jf-aap dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 arbitrary = { version="1.0", features=["derive"] }
 ark-std = { version = "0.3.0", default-features = false }
 itertools = "0.10.1"
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", branch = "keyao-tag" }
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "8c32d8df3faf511e54ad89fa51627837ebcd8f20" }
 rand_chacha = { version = "0.3.1", features = ["serde1"] }
 serde = { version = "1.0", features = ["derive"] }
 zerok-macros = { git = "ssh://git@github.com/SpectrumXYZ/zerok-macros.git" }


### PR DESCRIPTION
Depends on: https://github.com/SpectrumXYZ/jellyfish-apps/pull/89.