### PR TITLE
Updated reference to cap to the latest rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 arbitrary = { version="1.0", features=["derive"] }
 ark-std = { version = "0.3.0", default-features = false }
 itertools = "0.10.1"
-jf-cap = { features=["std"], git = "ssh://git@github.com/EspressoSystems/cap.git", rev = "cba0b2fc682606b0a118b320d41f718c525b4192" }
+jf-cap = { features=["std"], git = "ssh://git@github.com/EspressoSystems/cap.git", rev = "16ad157f96d2102d59206df0106fb341302180d3" }
 rand_chacha = { version = "0.3.1", features = ["serde1"] }
 serde = { version = "1.0", features = ["derive"] }
 zerok-macros = { git = "ssh://git@github.com/EspressoSystems/zerok-macros.git" }


### PR DESCRIPTION
Changelog: 
- https://github.com/EspressoSystems/cap/commit/c969d2bf741982b5fc5eeb1769f9e2ced84e87e0
- https://github.com/EspressoSystems/cap/commit/16ad157f96d2102d59206df0106fb341302180d3

Diff: https://github.com/EspressoSystems/cap/compare/cba0b2fc682606b0a118b320d41f718c525b4192...16ad157f96d2102d59206df0106fb341302180d3

Part of https://github.com/EspressoSystems/cape/pull/603
- [x] `cat Cargo.lock | grep Spectrum` returned no entries